### PR TITLE
Remove broken link to "Build an App in Pure JS" article

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@ To get started, simply fork this repo. Please refer to [CONTRIBUTING.md](CONTRIB
 ## JavaScript:
 
 - [Build 30 things in 30 days with 30 tutorials](https://javascript30.com)
-- [Build an App in Pure JS](https://medium.com/codingthesmartway-com-blog/pure-javascript-building-a-real-world-application-from-scratch-5213591cfcd6)
 - [Build a Jupyter Notebook Extension](https://link.medium.com/wWUO7TN8SS)
 - [Build a TicTacToe Game with JavaScript](https://medium.com/javascript-in-plain-english/build-tic-tac-toe-game-using-javascript-3afba3c8fdcc)
 - [Build a Simple Weather App With Vanilla JavaScript](https://webdesign.tutsplus.com/tutorials/build-a-simple-weather-app-with-vanilla-javascript--cms-33893)


### PR DESCRIPTION
# Remove broken link to "Build an App in Pure JS" article

## Description

I removed the link to the Medium article _“Build an App in Pure JS”_  
(`https://medium.com/codingthesmartway-com-blog/pure-javascript-building-a-real-world-application-from-scratch-5213591cfcd6`)  
because it now returns a **410 Gone** error with the message **“User deactivated or deleted their account.”**

## Motivation and Context

This change improves the quality of the repository by removing a link that no longer leads to valid content.  
Dead links can frustrate users and reduce trust in the resources provided.

## How Has This Been Tested?

The link was manually visited and confirmed to return a **410 Gone** error.  
No other parts of the file were modified.

## Types of changes

- [x] Content Update (change which fixes an issue or updates an already existing submission)
- [ ] New Article (change which adds functionality)
- [ ] Documentation change

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have made checks to ensure URLs and other resources are valid.
